### PR TITLE
LUT-27425 : do not display optional date when configuring an automatic task

### DIFF
--- a/src/java/fr/paris/lutece/plugins/workflow/modules/alertforms/service/AlertService.java
+++ b/src/java/fr/paris/lutece/plugins/workflow/modules/alertforms/service/AlertService.java
@@ -248,7 +248,10 @@ public final class AlertService implements IAlertService
         {
             int nIdEntryType = question.getEntry( ).getEntryType( ).getIdType( );
 
-            if ( isEntryTypeDateAccepted( nIdEntryType ) )
+            /*
+             * LUT-27425 If the date is set as optional in a form, then do not display this field when configuring an automatic alert task
+             * */
+            if ( isEntryTypeDateAccepted( nIdEntryType ) && question.getEntry().isMandatory() )
             {
                 refenreceListEntries.addItem( question.getId( ), buildReferenceEntryToString( question ) );
             }


### PR DESCRIPTION
If the date is not mondatory in a form, then do not display this field when configuring an automatic alert task.